### PR TITLE
Increment version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='license',
-    version='0.1a2',
+    version='0.1a3',
     description='Library that encapsulates free software licenses',
     long_description=''.join(open('README.rst').readlines()),
     keywords='license',


### PR DESCRIPTION
This should fix the #6:

This is caused by the package directory and the licence file having the same name in the different register (license and LICENSE). Could be fixed by adding an extension to the licence file.

It is fixed in the master branch, but not fixed in the distribution

