### PR TITLE
Makes `email` keyword optional.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,8 @@ Each license is a static class providing a few properties:
     'License :: OSI Approved :: MIT License'
 
 License classes also offer a static method ``render()`` that will output the entire license text.
-Some variables have to be passed to it, usually ``name``, ``email`` and optional ``year``
-(current year is used when omitted).
+Some variables have to be passed to it, usually ``name``, ``email`` (optional, if omitted or
+`None` no email address will be added) and ``year`` (optional, current year is used when omitted).
 
 .. code-block:: python
 
@@ -46,6 +46,17 @@ Some variables have to be passed to it, usually ``name``, ``email`` and optional
     '''The MIT License (MIT)
     
     Copyright (c) 2015 Petr Foo <petr@foo.org>
+    
+    Permission is hereby granted... (snip)'''
+
+or
+
+.. code-block:: python
+
+    mit.render(name='Petr Foo', year=2000)
+    '''The MIT License (MIT)
+    
+    Copyright (c) 2000 Petr Foo
     
     Permission is hereby granted... (snip)'''
 

--- a/license/templates/AGPL-3.0+__header
+++ b/license/templates/AGPL-3.0+__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by

--- a/license/templates/AGPL-3.0__header
+++ b/license/templates/AGPL-3.0__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by

--- a/license/templates/Apache-1.0
+++ b/license/templates/Apache-1.0
@@ -1,4 +1,4 @@
-Copyright (c) {{year}} {{ name }}{% if email is defined and email is string %} <{{email}}>{% endif %}.  All rights reserved.
+Copyright (c) {{year}} {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/license/templates/Apache-1.0
+++ b/license/templates/Apache-1.0
@@ -1,4 +1,4 @@
-Copyright (c) {{year}} {{ name }} <{{email}}>.  All rights reserved.
+Copyright (c) {{year}} {{ name }}{% if email is defined and email is string %} <{{email}}>{% endif %}.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions

--- a/license/templates/Apache-1.1
+++ b/license/templates/Apache-1.1
@@ -1,6 +1,6 @@
           The Apache Software License, Version 1.1
 
-Copyright (c) {{year}} {{ name }} <{{email}}>.  All rights
+Copyright (c) {{year}} {{ name }}{% if email is defined and email is string %} <{{email}}>{% endif %}.  All rights
 reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/license/templates/Apache-1.1
+++ b/license/templates/Apache-1.1
@@ -1,6 +1,6 @@
           The Apache Software License, Version 1.1
 
-Copyright (c) {{year}} {{ name }}{% if email is defined and email is string %} <{{email}}>{% endif %}.  All rights
+Copyright (c) {{year}} {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}.  All rights
 reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/license/templates/Apache-2.0__header
+++ b/license/templates/Apache-2.0__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/license/templates/BSD-2-Clause
+++ b/license/templates/BSD-2-Clause
@@ -1,4 +1,4 @@
-Copyright (c) {{year}}, {{name}} <{{email}}>
+Copyright (c) {{year}}, {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/license/templates/BSD-3-Clause
+++ b/license/templates/BSD-3-Clause
@@ -1,4 +1,4 @@
-Copyright (c) {{year}}, {{name}} <{{email}}>
+Copyright (c) {{year}}, {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/license/templates/GPL-2.0+__header
+++ b/license/templates/GPL-2.0+__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/license/templates/GPL-2.0__header
+++ b/license/templates/GPL-2.0__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/license/templates/GPL-3.0+__header
+++ b/license/templates/GPL-3.0+__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/license/templates/GPL-3.0__header
+++ b/license/templates/GPL-3.0__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/license/templates/LGPL-2.1+__header
+++ b/license/templates/LGPL-2.1+__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public

--- a/license/templates/LGPL-2.1__header
+++ b/license/templates/LGPL-2.1__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public

--- a/license/templates/LGPL-3.0+__header
+++ b/license/templates/LGPL-3.0+__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by

--- a/license/templates/LGPL-3.0__header
+++ b/license/templates/LGPL-3.0__header
@@ -1,4 +1,4 @@
-    Copyright (C) {{year}}  {{name}} <{{email}}>
+    Copyright (C) {{year}}  {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by

--- a/license/templates/MIT
+++ b/license/templates/MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) {{year}} {{ name }}{% if email is defined and email is string %} <{{email}}>{% endif %}
+Copyright (c) {{year}} {{name}}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/license/templates/MIT
+++ b/license/templates/MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) {{year}} {{ name }} <{{email}}>
+Copyright (c) {{year}} {{ name }}{% if email is defined and email is string %} <{{email}}>{% endif %}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I do not know, if the email address is a necessity with license files …

Anyway, if the `email` keyword is omitted (or set to `None`) when calling `.render()` or `.header()`, no email address is added to the license.

Would be good to have a new release with this feature :bow: